### PR TITLE
fixed callback order when unique is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ module.exports = exports = function sluggablePlugin(schema, options) {
                 }
                 if (!data) {
                     self[slug] = search;
-                    done();
                     next();
+                    done();
                     return;
                 }
                 findNewSlug(String(value) + String(separator) + String(++suffix));


### PR DESCRIPTION
when option unique is true, the callback in save was never fired because of wrong order.
